### PR TITLE
Added missing keywords and association with Kconfig files

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -5,8 +5,8 @@
 	"folding": {
 		"offSide": true,
 		"markers": {
-			"start": "^\\s*(if|menu)",
-			"end": "^\\s*(endif|endmenu)"
+			"start": "^\\s*(choice|if|menu)",
+			"end": "^\\s*(endchoice|endif|endmenu)"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "kconfig",
 	"displayName": "kconfig",
 	"description": "This extension provides syntax highlighting for the kbuild kconfig language. This is used for linux kernel (.config) and Buildroot (.in and .in.host) configuration files.",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"publisher": "luveti",
 	"repository": "https://github.com/luveti/kconfig-vscode",
 	"engines": {
@@ -15,7 +15,7 @@
 		"languages": [{
 			"id": "kconfig",
 			"aliases": ["kconfig", "kconfig"],
-			"extensions": [".config",".in",".in.host"],
+			"extensions": [".config",".in",".in.host","Kconfig","Kconfig.*"],
 			"configuration": "./language-configuration.json"
 		}],
 		"grammars": [{

--- a/syntaxes/kconfig.tmLanguage.json
+++ b/syntaxes/kconfig.tmLanguage.json
@@ -36,7 +36,7 @@
 				"match": "\\b(default|depends on|help|prompt|select)\\b"
 			}, {
 				"name": "keyword",
-				"match": "\\b(bool|hex|int|string|tristate)\\b"
+				"match": "\\b(bool|def_bool|def_tristate|hex|int|string|tristate)\\b"
 			}, {
 				"name": "keyword",
 				"match": "\\B(\\|\\||&&)\\B"

--- a/syntaxes/kconfig.tmLanguage.json
+++ b/syntaxes/kconfig.tmLanguage.json
@@ -30,7 +30,7 @@
 		"keywords": {
 			"patterns": [{
 				"name": "keyword",
-				"match": "\\b(comment|config|endif|endmenu|if|menu|source)\\b"
+				"match": "\\b(choice|comment|config|endchoice|endif|endmenu|if|mainmenu|menu|menuconfig|source)\\b"
 			}, {
 				"name": "keyword",
 				"match": "\\b(default|depends on|help|prompt|select)\\b"

--- a/syntaxes/kconfig.tmLanguage.json
+++ b/syntaxes/kconfig.tmLanguage.json
@@ -30,7 +30,10 @@
 		"keywords": {
 			"patterns": [{
 				"name": "keyword",
-				"match": "\\b(comment|config|default|depends on|endif|endmenu|help|if|menu|prompt|select|source)\\b"
+				"match": "\\b(comment|config|endif|endmenu|if|menu|source)\\b"
+			}, {
+				"name": "keyword",
+				"match": "\\b(default|depends on|help|prompt|select)\\b"
 			}, {
 				"name": "keyword",
 				"match": "\\b(bool|hex|int|string|tristate)\\b"

--- a/syntaxes/kconfig.tmLanguage.json
+++ b/syntaxes/kconfig.tmLanguage.json
@@ -33,7 +33,7 @@
 				"match": "\\b(choice|comment|config|endchoice|endif|endmenu|if|mainmenu|menu|menuconfig|source)\\b"
 			}, {
 				"name": "keyword",
-				"match": "\\b(default|depends on|help|prompt|select)\\b"
+				"match": "\\b(allnoconfig_y|defconfig_list|default|depends on|help|imply|modules|option|prompt|range|select|visible if)\\b"
 			}, {
 				"name": "keyword",
 				"match": "\\b(bool|def_bool|def_tristate|hex|int|string|tristate)\\b"


### PR DESCRIPTION
I used this extension to study the Kconfig files from the recent https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.6.tar.xz and noticed that it did not recognise some keywords from the Kconfig spec:

- type definition shorthands `def_bool` and `def_tristate` 
- entries `mainmenu`, `menuconfig` and `choice|endchoice`
- attributes `imply`, `range`, `visible if` and `option` (and its 3 possible options) 

I fixed these and added association with `Kconfig` and `Kconfig.*` files since these are used in the Linux source tree.

The files I used for testing:

- linux-5.6/init/Kconfig
- linux-5.6/arch/arm/Kconfig
- linux-5.6/arch/s390/
- linux-5.6/drivers/i2c/algos/KconfigKconfig